### PR TITLE
Fix the TypeError that occurs when the model is on 'cuda' and there i…

### DIFF
--- a/khamyo/core.py
+++ b/khamyo/core.py
@@ -22,58 +22,67 @@ tokenizer = Tokenizer(list_th+list(thai_words()), engine='newmm')
 
 
 def merge(l: list) -> list:
-  list_sent = []
-  temp = ""
-  for i in l:
-    if i not in list_th:
-      temp += i
-    elif temp!="":
-      list_sent.append(temp)
-      list_sent.append(i)
-      temp = ""
-    else:
-      list_sent.append(i)
-  if temp!="":
-    list_sent.append(temp)
-  return list_sent
+    list_sent = []
+    temp = ""
+    for i in l:
+        if i not in list_th:
+            temp += i
+        elif temp!="":
+            list_sent.append(temp)
+            list_sent.append(i)
+            temp = ""
+        else:
+            list_sent.append(i)
+    if temp!="":
+        list_sent.append(temp)
+    return list_sent
 
 
 def counts(l: list) -> defaultdict:
-  _temp = defaultdict(int)
-  for i in l:
-    if i in list_th:
-      _temp[i]+=1
-  return _temp
+    _temp = defaultdict(int)
+    for i in l:
+        if i in list_th:
+            _temp[i]+=1
+    return _temp
 
 
 def replace(sentence: str, top_k: int = 2) -> list:
-  sent_words = tokenizer.word_tokenize(sentence)
-  c = counts(sent_words)
-  if c == {}:
-    return [(sentence,None)]
-  del c
-  list_index = []
-  list_temp = []
-  j = 0
-  for i,w in enumerate(sent_words):
-    if w in list_th:
-      if len(worddict[w])>1:
-        list_index.append(i)
-        list_temp.append(worddict[w])
-      else:
-        sent_words[i] = worddict[w][0]
-  sum_m = list(itertools.product(*list_temp))
-  list_sent = []
-  sentence_embedding = model.encode(sentence, convert_to_tensor=True)
-  for i,v in enumerate(sum_m):
-    _t = copy.copy(sent_words)
-    for j,w in enumerate(v):
-      _t[list_index[j]] = w
-    list_sent.append(''.join(_t))
-  if len(sum_m) == 1:
-      s2 = model.encode(list_sent[0], convert_to_tensor=True)
-      return [(list_sent[0],util.pytorch_cos_sim(sentence_embedding,s2))]
-  corpus_embeddings = model.encode(list_sent, convert_to_tensor=True)
-  cos_scores = util.pytorch_cos_sim(sentence_embedding, corpus_embeddings)[0]
-  top_results = np.argpartition(-cos_scores, range(top_k))[0:top_k]
-  return [(list_sent[i], cos_scores[i]) for i in top_results[0:top_k].tolist()]
+    sent_words = tokenizer.word_tokenize(sentence)
+    c = counts(sent_words)
+    if c == {}:
+        return [(sentence,None)]
+    del c
+
+    list_index = []
+    list_temp = []
+    j = 0
+    for i,w in enumerate(sent_words):
+        if w in list_th:
+            if len(worddict[w])>1:
+                list_index.append(i)
+                list_temp.append(worddict[w])
+            else:
+                sent_words[i] = worddict[w][0]
+    sum_m = list(itertools.product(*list_temp))
+
+    list_sent = []
+    sentence_embedding = model.encode(sentence, convert_to_tensor=True)
+    for i,v in enumerate(sum_m):
+        _t = copy.copy(sent_words)
+        for j,w in enumerate(v):
+            _t[list_index[j]] = w
+        list_sent.append(''.join(_t))
+
+    if len(sum_m) == 1:
+        s2 = model.encode(list_sent[0], convert_to_tensor=True)
+        return [(list_sent[0],util.pytorch_cos_sim(sentence_embedding,s2))]
+
+    corpus_embeddings = model.encode(list_sent, convert_to_tensor=True)
+    cos_scores = util.pytorch_cos_sim(sentence_embedding, corpus_embeddings)[0]
+    
+    # Check if cos_scores are on 'cuda'; if so, move them to 'cpu'.
+    if cos_scores.is_cuda:
+        cos_scores = cos_scores.to('cpu')
+
+    top_results = np.argpartition(-cos_scores, range(top_k))[0:top_k]
+    return [(list_sent[i], cos_scores[i]) for i in top_results[0:top_k].tolist()]


### PR DESCRIPTION
### What does this changes
- Fix the TypeError that occurs when the model is on 'cuda' and there is more than one possible result.
- Add proper indent in the code.

### What was wrong
> ---> 41 top_results = np.argpartition(-cos_scores, range(top_k))[0:top_k]

> TypeError: can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.

When the model is on 'cuda' and there is more than one possible result of `sum_m` `(len(sum_m) > 1)`, `cos_scores` will be on 'cuda' as well, resulting in an error at
```
top_results = np.argpartition(-cos_scores, range(top_k))[0:top_k]
```

### How this fixes it
Move `cos_scores` to 'cpu' if it is on 'cuda'.